### PR TITLE
Cleaner layout for grouped tables.

### DIFF
--- a/static/scripts/S3/s3.ui.groupeditems.js
+++ b/static/scripts/S3/s3.ui.groupeditems.js
@@ -304,7 +304,7 @@
                         }
                         if (titleSpan > 1) {
                             footerLabel = $('<td class="gi-group-footer-label" colspan="' + titleSpan + '">').html(value);
-                            $('<span> ' + opts.totalsLabel + '</span>').appendTo(footerLabel);
+                            $('<span class="gi-group-footer-inline-label"> ' + opts.totalsLabel + '</span>').appendTo(footerLabel);
                             footerLabel.appendTo(footerRow);
                         }
                     }

--- a/static/themes/default/report.css
+++ b/static/themes/default/report.css
@@ -230,3 +230,40 @@
 .pt-table-contents {
   clear: left;
 }
+
+/* In grouped tables, separate groups visually */
+.gi-table table {
+  border-collapse: separate;
+}
+.gi-table table thead td,
+.gi-table table tfoot td {
+  background-color: #333;
+  color: #fff;
+}
+
+.gi-group-footer.gi-level-1 td {
+  background-color: #999;
+  color: #fff;
+}
+.gi-group-footer.gi-level-1 td a {
+  color: #fff;
+}
+
+.gi-group-footer.gi-level-2 td {
+  border-bottom: 1px solid #999;
+  background-color: #f3f3f3;
+}
+
+/* Show label for summary in tables */
+.gi-group-footer-inline-label {
+  display: inline-block;
+  font-size: 11px;
+  line-height: 1;
+  position: relative;
+  top: -0.1em;
+  margin: 0 0.25em 0 1em;
+  padding: 0.25em 0.75em;
+  text-transform: uppercase;
+  background-color: #ccc;
+  color: #666;
+}


### PR DESCRIPTION
This adds a cleaner layout for big grouped tables (like warehouse stock report).

Please let me know if this is correct and if I should still do a PR on the `edenthemes` repository. I couldn’t submit the compiled files as I didn’t knew if this is expected but more because of too many compile steps done with closure compiler. To be honest, the compilation of Scss/CSS files looks still a bit odd to me and to me seems unnecessary complex.

Please let me know if it’s the right direction or if something important is missing.