### PR TITLE
Avoid layout reflow when filter triggers throbber.

### DIFF
--- a/static/scripts/S3/s3.ui.groupeditems.js
+++ b/static/scripts/S3/s3.ui.groupeditems.js
@@ -112,7 +112,7 @@
             this._bindEvents();
 
             // Hide throbber
-            el.find('.gi-throbber').hide();
+            el.find('.gi-throbber').css('visibility', 'hidden');;
         },
 
         /**
@@ -366,7 +366,7 @@
             var self = this,
                 needs_reload = false;
 
-            $(this.element).find('.gi-throbber').show();
+            $(this.element).find('.gi-throbber').css('visibility', 'visible');
 
             if (options || filters) {
                 needs_reload = this._updateAjaxURL(options, filters);


### PR DESCRIPTION
This is a temporary fix until a proper `show()`/`hide()` replacement can be figured out and tested.